### PR TITLE
Use poetry-core as build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dump_state_name_completions = 'salt_lsp.cmds:dump_state_name_completions'
 pytest-lsp = "^0.4.3"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Hello there,

using plain poetry breaks packaging on NixOS (See https://github.com/NixOS/nixpkgs/issues/103325 and similar)

As a result, I've updated pyproject.toml 😄 